### PR TITLE
Applicable regions Menu and Global Region easy config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,3 +24,8 @@ jobs:
         cache: maven
     - name: Build with Maven
       run: mvn -B package --file pom.xml
+    - name: Upload Jar
+      uses: actions/upload-artifact@v3
+      with:
+        name: plugin
+        path: WorldGuardGUIPlugin/target/WorldGuardGUI*.jar

--- a/WG6/src/main/java/me/heymrau/wg6/WorldGuard6Hook.java
+++ b/WG6/src/main/java/me/heymrau/wg6/WorldGuard6Hook.java
@@ -1,10 +1,15 @@
 package me.heymrau.wg6;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.sk89q.worldedit.BlockVector;
+import com.sk89q.worldedit.Vector;
 import com.sk89q.worldguard.bukkit.RegionContainer;
 import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
 import com.sk89q.worldguard.protection.flags.*;
 import com.sk89q.worldguard.protection.managers.RegionManager;
+import com.sk89q.worldguard.protection.regions.GlobalProtectedRegion;
 import com.sk89q.worldguard.protection.regions.ProtectedCuboidRegion;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import me.heymrau.worldguardhook.WorldGuardLocation;
@@ -119,6 +124,26 @@ public class WorldGuard6Hook implements WorldGuardService {
         if(flag == null) return;
         flag.remove(command);
         region.setFlag(DefaultFlag.BLOCKED_CMDS, flag);
+    }
+
+    @Override
+    public Set<ProtectedRegion> getApplicableRegions(WorldGuardLocation location) {
+        RegionManager manager = WorldGuardPlugin.inst().getRegionManager(Bukkit.getWorld(location.getWorldName()));
+        ApplicableRegionSet applicableRegions = manager.getApplicableRegions(
+                new Vector(location.getX(), location.getY(), location.getZ())
+        );
+
+        ProtectedRegion globalRegion = manager.getRegion(GLOBAL_REGION);
+
+        if(globalRegion == null) {
+            globalRegion = new GlobalProtectedRegion(GLOBAL_REGION);
+            manager.addRegion(globalRegion);
+        }
+
+        ArrayList<ProtectedRegion> protectedRegions = Lists.newArrayList(applicableRegions);
+        protectedRegions.add(0, globalRegion);
+
+        return Sets.newLinkedHashSet(protectedRegions);
     }
 
     @Override

--- a/WG7/src/main/java/me/heymrau/wg7/WorldGuard7Hook.java
+++ b/WG7/src/main/java/me/heymrau/wg7/WorldGuard7Hook.java
@@ -1,12 +1,17 @@
 package me.heymrau.wg7;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
 import com.sk89q.worldguard.protection.flags.Flag;
 import com.sk89q.worldguard.protection.flags.Flags;
 import com.sk89q.worldguard.protection.flags.StateFlag;
 import com.sk89q.worldguard.protection.managers.RegionManager;
+import com.sk89q.worldguard.protection.regions.GlobalProtectedRegion;
 import com.sk89q.worldguard.protection.regions.ProtectedCuboidRegion;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import com.sk89q.worldguard.protection.regions.RegionContainer;
@@ -155,5 +160,27 @@ public class WorldGuard7Hook implements WorldGuardService {
     public StateFlag getFlagByName(String flagName) {
         Flag<?> flag = WorldGuard.getInstance().getFlagRegistry().get(flagName);
         return flag instanceof StateFlag ? (StateFlag) flag : null;
+    }
+
+    @Override
+    public Set<ProtectedRegion> getApplicableRegions(WorldGuardLocation location) {
+        RegionManager manager =  WorldGuard.getInstance().getPlatform().getRegionContainer()
+                .get(BukkitAdapter.adapt(Bukkit.getWorld(location.getWorldName())));
+
+        ApplicableRegionSet applicableRegions = manager.getApplicableRegions(
+                BlockVector3.at(location.getX(), location.getY(), location.getZ())
+        );
+
+        ProtectedRegion globalRegion = manager.getRegion(GLOBAL_REGION);
+
+        if(globalRegion == null) {
+            globalRegion = new GlobalProtectedRegion(GLOBAL_REGION);
+            manager.addRegion(globalRegion);
+        }
+
+        ArrayList<ProtectedRegion> protectedRegions = Lists.newArrayList(applicableRegions);
+        protectedRegions.add(0, globalRegion);
+
+        return Sets.newLinkedHashSet(protectedRegions);
     }
 }

--- a/WorldGuardGUIPlugin/src/main/java/me/heymrau/worldguardguiplugin/commands/WGGuiCommand.java
+++ b/WorldGuardGUIPlugin/src/main/java/me/heymrau/worldguardguiplugin/commands/WGGuiCommand.java
@@ -3,6 +3,7 @@ package me.heymrau.worldguardguiplugin.commands;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import me.heymrau.worldguardguiplugin.WorldGuardGUIPlugin;
 import me.heymrau.worldguardguiplugin.inventories.MainInventory;
+import me.heymrau.worldguardguiplugin.inventories.RegionsOnTopInventory;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -21,7 +22,7 @@ public class WGGuiCommand implements CommandExecutor {
         if (!(sender instanceof Player) || !sender.hasPermission("worldguardgui.gui")) return true;
         Player player = (Player) sender;
         if (args.length != 1) {
-            player.sendMessage(colored("&cUsage: /wggui <region>"));
+            new RegionsOnTopInventory(plugin).open(player, null);
             return true;
         }
         String regionName = args[0];

--- a/WorldGuardGUIPlugin/src/main/java/me/heymrau/worldguardguiplugin/inventories/MainInventory.java
+++ b/WorldGuardGUIPlugin/src/main/java/me/heymrau/worldguardguiplugin/inventories/MainInventory.java
@@ -9,6 +9,7 @@ import me.heymrau.worldguardguiplugin.inventories.permission.InventoryPermission
 import me.heymrau.worldguardguiplugin.model.Template;
 import me.heymrau.worldguardguiplugin.utils.Utils;
 import me.heymrau.worldguardguiplugin.utils.XMaterial;
+import me.heymrau.worldguardhook.WorldGuardService;
 import net.kyori.adventure.text.Component;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -23,7 +24,6 @@ public class MainInventory extends Inventory {
     }
 
     public void open(Player player, ProtectedRegion region) {
-        // TODO: if is Global region, we should disable a bunch of things
         if (!region.getOwners().contains(player.getUniqueId()) && !player.hasPermission("worldguardgui.admin")) {
             player.sendMessage(ChatColor.RED + "You don't have permission to use this GUI!");
             return;
@@ -31,6 +31,7 @@ public class MainInventory extends Inventory {
 
         Gui gui = Gui.gui().rows(5).title(Utils.colored("WorldGuard GUI")).disableAllInteractions().create();
 
+        boolean isNotGlobal = !region.getId().equals(WorldGuardService.GLOBAL_REGION);
 
         GuiItem flagItem = ItemBuilder.from(XMaterial.GRASS_BLOCK.parseMaterial())
                 .name(Utils.colored("&aManage region flags"))
@@ -80,13 +81,13 @@ public class MainInventory extends Inventory {
                 });
 
         gui.setItem(11, flagItem);
-        gui.setItem(12, parentItem);
+        if(isNotGlobal) gui.setItem(12, parentItem);
         gui.setItem(13, templateItem);
-        gui.setItem(14, borderItem);
-        gui.setItem(15, renameItem);
+        if(isNotGlobal) gui.setItem(14, borderItem);
+        if(isNotGlobal) gui.setItem(15, renameItem);
         gui.setItem(21, saveTemplateItem);
         gui.setItem(23, commandItem);
-        gui.setItem(40, deleteItem);
+        if(isNotGlobal) gui.setItem(40, deleteItem);
 
         gui.open(player);
     }

--- a/WorldGuardGUIPlugin/src/main/java/me/heymrau/worldguardguiplugin/inventories/MainInventory.java
+++ b/WorldGuardGUIPlugin/src/main/java/me/heymrau/worldguardguiplugin/inventories/MainInventory.java
@@ -23,6 +23,7 @@ public class MainInventory extends Inventory {
     }
 
     public void open(Player player, ProtectedRegion region) {
+        // TODO: if is Global region, we should disable a bunch of things
         if (!region.getOwners().contains(player.getUniqueId()) && !player.hasPermission("worldguardgui.admin")) {
             player.sendMessage(ChatColor.RED + "You don't have permission to use this GUI!");
             return;

--- a/WorldGuardGUIPlugin/src/main/java/me/heymrau/worldguardguiplugin/inventories/MainInventory.java
+++ b/WorldGuardGUIPlugin/src/main/java/me/heymrau/worldguardguiplugin/inventories/MainInventory.java
@@ -29,9 +29,10 @@ public class MainInventory extends Inventory {
             return;
         }
 
-        Gui gui = Gui.gui().rows(5).title(Utils.colored("WorldGuard GUI")).disableAllInteractions().create();
-
         boolean isNotGlobal = !region.getId().equals(WorldGuardService.GLOBAL_REGION);
+        String globalMenuName = isNotGlobal ? "" : " &6(Global)";
+
+        Gui gui = Gui.gui().rows(5).title(Utils.colored("WorldGuard GUI" + globalMenuName)).disableAllInteractions().create();
 
         GuiItem flagItem = ItemBuilder.from(XMaterial.GRASS_BLOCK.parseMaterial())
                 .name(Utils.colored("&aManage region flags"))

--- a/WorldGuardGUIPlugin/src/main/java/me/heymrau/worldguardguiplugin/inventories/RegionsOnTopInventory.java
+++ b/WorldGuardGUIPlugin/src/main/java/me/heymrau/worldguardguiplugin/inventories/RegionsOnTopInventory.java
@@ -1,5 +1,6 @@
 package me.heymrau.worldguardguiplugin.inventories;
 
+import com.google.common.collect.Sets;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import dev.triumphteam.gui.builder.item.ItemBuilder;
 import dev.triumphteam.gui.guis.Gui;
@@ -21,6 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Menu with all the regions that the player is currently on top.
@@ -35,22 +37,30 @@ public class RegionsOnTopInventory extends Inventory {
     }
 
     public void open(Player player, ProtectedRegion _ignore) {
-        // TODO: support filtering if the player is Owner
-        // TODO: if there is only one region, open directly the MainInventoryMenu
+        Location location = player.getLocation();
+        WorldGuardLocation worldGuardLocation = new WorldGuardLocation(player.getWorld().getName(), location.getBlockX(), location.getBlockY(), location.getBlockZ());
+        Set<ProtectedRegion> applicableRegions = plugin.getWorldGuard().getApplicableRegions(worldGuardLocation);
+
         if (!player.hasPermission("worldguardgui.admin")) {
-            player.sendMessage(ChatColor.RED + "You don't have permission to use this GUI!");
+            applicableRegions = Sets.newLinkedHashSet(applicableRegions.stream().filter((i) -> i.getOwners().contains(player.getUniqueId())).collect(Collectors.toList()));
+        }
+
+        if(applicableRegions.isEmpty()) {
+            player.sendMessage(ChatColor.RED + "You are not in a Region that you own!");
+            return;
+        }
+
+        if(applicableRegions.size() == 1) {
+            new MainInventory(plugin).open(player, applicableRegions.stream().findFirst().get());
             return;
         }
 
         PaginatedGui gui = Gui.paginated()
-                .rows(1)
+                .rows(2)
                 .pageSize(9)
                 .title(Utils.colored("&7Regions on Top"))
                 .disableAllInteractions()
                 .create();
-        Location location = player.getLocation();
-        WorldGuardLocation worldGuardLocation = new WorldGuardLocation(player.getWorld().getName(), location.getBlockX(), location.getBlockY(), location.getBlockZ());
-        Set<ProtectedRegion> applicableRegions = plugin.getWorldGuard().getApplicableRegions(worldGuardLocation);
 
         applicableRegions.forEach((region) -> {
             XMaterial iconMaterial = region.getId().equals(ProtectedRegion.GLOBAL_REGION) ? XMaterial.BEDROCK : XMaterial.GRASS_BLOCK;

--- a/WorldGuardGUIPlugin/src/main/java/me/heymrau/worldguardguiplugin/inventories/RegionsOnTopInventory.java
+++ b/WorldGuardGUIPlugin/src/main/java/me/heymrau/worldguardguiplugin/inventories/RegionsOnTopInventory.java
@@ -1,0 +1,70 @@
+package me.heymrau.worldguardguiplugin.inventories;
+
+import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+import dev.triumphteam.gui.builder.item.ItemBuilder;
+import dev.triumphteam.gui.guis.Gui;
+import dev.triumphteam.gui.guis.GuiItem;
+import dev.triumphteam.gui.guis.PaginatedGui;
+import me.heymrau.worldguardguiplugin.WorldGuardGUIPlugin;
+import me.heymrau.worldguardguiplugin.inventories.permission.InventoryPermission;
+import me.heymrau.worldguardguiplugin.model.CustomItem;
+import me.heymrau.worldguardguiplugin.utils.Utils;
+import me.heymrau.worldguardguiplugin.utils.XMaterial;
+import me.heymrau.worldguardhook.WorldGuardLocation;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Menu with all the regions that the player is currently on top.
+ */
+public class RegionsOnTopInventory extends Inventory {
+    private final WorldGuardGUIPlugin plugin;
+
+
+    public RegionsOnTopInventory(WorldGuardGUIPlugin plugin) {
+        super(InventoryPermission.PARENT);
+        this.plugin = plugin;
+    }
+
+    public void open(Player player, ProtectedRegion _ignore) {
+        // TODO: support filtering if the player is Owner
+        // TODO: if there is only one region, open directly the MainInventoryMenu
+        if (!player.hasPermission("worldguardgui.admin")) {
+            player.sendMessage(ChatColor.RED + "You don't have permission to use this GUI!");
+            return;
+        }
+
+        PaginatedGui gui = Gui.paginated()
+                .rows(1)
+                .pageSize(9)
+                .title(Utils.colored("&7Regions on Top"))
+                .disableAllInteractions()
+                .create();
+        Location location = player.getLocation();
+        WorldGuardLocation worldGuardLocation = new WorldGuardLocation(player.getWorld().getName(), location.getBlockX(), location.getBlockY(), location.getBlockZ());
+        Set<ProtectedRegion> applicableRegions = plugin.getWorldGuard().getApplicableRegions(worldGuardLocation);
+
+        applicableRegions.forEach((region) -> {
+            XMaterial iconMaterial = region.getId().equals(ProtectedRegion.GLOBAL_REGION) ? XMaterial.BEDROCK : XMaterial.GRASS_BLOCK;
+
+            List<String> lore = Arrays.asList("&7", "&eClick to open Region configuration");
+            ItemStack regionItem = new CustomItem("&a" + region.getId(), lore, iconMaterial.parseMaterial(), false, (short) 0, 1).complete();
+
+            GuiItem guiItem = ItemBuilder.from(regionItem).asGuiItem(event -> {
+                new MainInventory(plugin).open(player, region);
+            });
+
+            gui.addItem(guiItem);
+        });
+        plugin.getInventoryManager().setupPageButtons(gui);
+        gui.open(player);
+    }
+}

--- a/WorldGuardGUIPlugin/src/main/java/me/heymrau/worldguardguiplugin/managers/InventoryManager.java
+++ b/WorldGuardGUIPlugin/src/main/java/me/heymrau/worldguardguiplugin/managers/InventoryManager.java
@@ -7,13 +7,14 @@ import org.bukkit.Material;
 
 public class InventoryManager {
     public void setupPageButtons(PaginatedGui paginatedGui) {
-        paginatedGui.setItem(5, 3, ItemBuilder.from(Material.ARROW)
+        int finalRow = paginatedGui.getRows();
+        paginatedGui.setItem(finalRow, 3, ItemBuilder.from(Material.ARROW)
                 .name(Utils.colored("&6Previous Page"))
                 .asGuiItem(event -> paginatedGui.previous()));
-        paginatedGui.setItem(5, 5, ItemBuilder.from(Material.BARRIER)
+        paginatedGui.setItem(finalRow, 5, ItemBuilder.from(Material.BARRIER)
                 .name(Utils.colored("&cClose"))
                 .asGuiItem(event1 -> paginatedGui.close(event1.getWhoClicked())));
-        paginatedGui.setItem(5, 7, ItemBuilder.from(Material.ARROW)
+        paginatedGui.setItem(finalRow, 7, ItemBuilder.from(Material.ARROW)
                 .name(Utils.colored("&6Next Page"))
                 .asGuiItem(event -> paginatedGui.next()));
     }

--- a/WorldGuardHook/src/main/java/me/heymrau/worldguardhook/WorldGuardService.java
+++ b/WorldGuardHook/src/main/java/me/heymrau/worldguardhook/WorldGuardService.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import java.util.Set;
 
 public interface WorldGuardService {
+    public static final String GLOBAL_REGION = "__global__";
+
     void remove(String regionName);
     void allowFlag(ProtectedRegion region, StateFlag flag);
     void denyFlag(ProtectedRegion region, StateFlag flag);
@@ -23,4 +25,5 @@ public interface WorldGuardService {
     Set<String> getBlockedCommands(ProtectedRegion region);
     void addBlockedCommand(ProtectedRegion region, String command);
     void removeBlockedCommand(ProtectedRegion region, String command);
+    Set<ProtectedRegion> getApplicableRegions(WorldGuardLocation location);
 }


### PR DESCRIPTION
This pull request adds support for Applicable regions Menu, this will make easy to configure regions inside regions and also know that region you want to configure, if you are a ADMIN, you will have the GLOBAL region that you can configure.

- If you are an admin and call /wggui, it should open directly the Global Region setup if you are not inside any other region.
- If you are a player and own the region, it should open directly the region on are on top.

**This pull request also adds the publish of artifact in Github Action workflow**

![image](https://github.com/osmanfurkan115/WorldGuardGUI/assets/29736164/9816b6a3-612b-4124-ba6d-91ac9051e7f9)

![image](https://github.com/osmanfurkan115/WorldGuardGUI/assets/29736164/42211b3b-1b31-4f9b-a5ca-a4399877f6d9)

On Global Region, the options is limited, you can't rename it, you can't remove it, etc.

![image](https://github.com/osmanfurkan115/WorldGuardGUI/assets/29736164/69b12ecd-4c34-48f4-a536-eac026b072ad)

### **You can download the plugin here at artifacts:** https://github.com/KotlinMinecraft/WorldGuardGUI/actions/runs/5236648611